### PR TITLE
Fix Missing Language Dropdown on Default Locale

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,6 +84,7 @@ const config = {
           {
             type: 'localeDropdown',
             position: 'right',
+            dropdownActiveClassDisabled: true,
           },
         ],
       },


### PR DESCRIPTION
This PR fixes an issue where the language dropdown was not visible when viewing the default Swedish locale (/ route). While the dropdown correctly appeared on /en/, users could not switch languages from the homepage or other Swedish routes.

Fix:
- Set dropdownActiveClassDisabled: true on the localeDropdown config item

This ensures the language selector is always visible, regardless of active locale