### PR TITLE
docs: add Google Analytics integration guide (English + Swedish)

### DIFF
--- a/docs/snabbstart/marvify-viewer.md
+++ b/docs/snabbstart/marvify-viewer.md
@@ -102,3 +102,93 @@ Bädda in vår modul en gång och placera sedan det anpassade elementet där du 
 * **Zoom känns för stark/svag:** Justera `minZoom`/`maxZoom`; värdena är relativa till modellens storlek.
 * **Kameran startar i en konstig vinkel:** Använd `initialCameraAngle="yaw pitch"` för att åsidosätta standardinställningen.
 * **Layouten kapas på små ytor:** Ange en explicit `height` på värdelementet.
+
+## Google Analytics
+
+Du kan koppla Marvify Model Viewer till din egen Google Analytics 4 (GA4)-installation. På så sätt kan du spåra användning av dina 3D-modeller direkt i GA-rapporter.
+
+### Snabbstart
+
+1. Säkerställ att GA4 är installerat på din webbplats, eller använd Google Tag Manager med en GA4-tagg.  
+2. Lägg till ditt GA-mätnings-ID i Marvify-skriptet.
+
+```html
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<!-- Din GA4-setup -->
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+<!-- lägg till ditt measurement-id i script-importen -->
+<script src="https://js.marvify.io/marvify.js" type="module"
+        data-ga4-id="G-XXXXXXXXXX"></script>
+
+<marvify-model-viewer model-id="demo" style="width:300px; height:300px"></marvify-model-viewer>
+```
+
+Byt ut `G-XXXXXXXXXX` mot ditt eget GA4-mätnings-ID.
+
+---
+
+### Händelser som spåras
+
+Visaren skickar automatiskt tre standardhändelser till GA, en gång per aktivering av visaren.
+
+* `marvify_viewer_session_requested`:  
+  * skickas när en besökare eller auto-play aktiverar visaren, till exempel genom att klicka för att starta.  
+* `marvify_viewer_session_displayed`:  
+  * skickas när modellen har laddats klart.  
+* `marvify_viewer_session_interacted`:  
+  * skickas vid den första interaktionen efter laddning, till exempel klick, rotation, zoom eller gest.  
+
+---
+
+### Anpassa händelsenamn
+
+Om du föredrar andra händelsenamn kan du mappa om dem via ett skriptattribut.
+
+```html
+<script src="https://js.marvify.io/marvify.js" type="module"
+        data-ga4-id="G-XXXXXXXXXX"
+        data-insights-rename='{
+          "marvify_viewer_session_requested":"viewer_use",
+          "marvify_viewer_session_displayed":"viewer_display",
+          "marvify_viewer_session_interacted":"viewer_interact"
+        }'></script>
+```
+
+---
+
+### Skicka händelser till GTM
+
+Om du redan använder **Google Tag Manager (GTM)** som din analysplattform kan du vidarebefordra Marvify-händelser till `dataLayer`. Därifrån bestämmer du själv hur de ska hanteras i GTM (till exempel till GA4 eller ett annat verktyg).
+
+**Steg 1 – Lägg till en global handler**
+
+```html
+<script>
+  window.dataLayer = window.dataLayer || [];
+  window.MarvifyEventHandler = function(eventName, payload) {
+    window.dataLayer.push({
+      event: eventName,
+      ...payload
+    });
+  };
+</script>
+```
+
+**Steg 2 – Tala om för visaren att använda den handlern**
+
+```html
+<script src="https://js.marvify.io/marvify.js" type="module"
+        data-insights-handler="MarvifyEventHandler"></script>
+```
+
+När detta är konfigurerat kommer Marvify-händelser att visas i din `dataLayer`. Inuti GTM kan du skapa Custom Event-triggers för dessa händelser och koppla GA4- eller andra taggar till dem.
+
+---
+
+Med denna konfiguration visas interaktioner i 3D-visaren i Google Analytics precis som andra händelser. Du kan behålla standardnamnen, byta ut dem eller helt anpassa routingen via GTM.

--- a/i18n/en/docusaurus-plugin-content-docs/current/snabbstart/marvify-viewer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/snabbstart/marvify-viewer.md
@@ -5,13 +5,14 @@ sidebar_label: Marvify Viewer
 ---
 # Marvify Model Viewer
 
-*A drop‑in web component for rendering 3D product models on your site.*
+*A drop-in web component for rendering 3D product models on your site.*
 
 ---
 ## What You Need
 
 To use Marvify with your own models, you must be a Marvify customer with provisioned models by us. However, you can try out the viewer without an account by using our demo model. Simply set `model-id="demo"` and ensure you are running your development site on `localhost` in your browser. The demo model is only available when served from `localhost`, so testing via an IP address will not work (e.g. 127.0.0.1).
 
+---
 
 ## Quick Start
 
@@ -29,7 +30,6 @@ Embed our module script once, then place the custom element where you want the v
 ```
 
 **Minimum required attributes:** `model-id`, `width`.
-
 
 ---
 
@@ -76,34 +76,123 @@ Embed our module script once, then place the custom element where you want the v
 
 ## Custom Attributes
 
-| Attribute                        | Type / Range         |        Default | Description                                                                                                                  |
-| -------------------------------- | -------------------- | -------------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `model-id` **(required)**        | string               |              — | model identifier in Marvify's service.                                                        |
-| `width` **(required)**                         | CSS length           |              — | Sets element width (e.g., `320px`, `100%`).                                 |
-| `height`                         | CSS length           |              — | Sets host element height.                                                                                                    |
-| `fullscreen`                     | boolean   |            off | When present, the viewer takes over the viewport (`position: fixed; top/left: 0; width/height: 100vw/100vh; z-index: 9999`). |
-| `bgColor`                        | CSS color            |      `#f2f2f2` | Background color. Hex, rgb(a) supported.                                                                               |
-| `fov`                            | number (deg)         |           `55` | Camera field‑of‑view.                                                                                                        |                                                                                                        |
-| `minZoom`, `maxZoom`             | number               |           auto | Minimum and Maximum zoom allowed                                   |
-| `minCameraTilt`, `maxCameraTilt` | number (deg)         |    `10` / `85` | Pitch angle clamps (lock camera from going up or down too much).                                                                                                          |
-| `initialCameraAngle`             | string `"yaw pitch"` | `"0 0"` | change starting camera position horizontal vertical (e.g. -45 90)               |
-
+| Attribute                        | Type or Range        | Default | Description                                                                                                                   |
+| -------------------------------- | -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `model-id` **(required)**        | string               | n/a     | Model identifier in Marvify's service.                                                                                        |
+| `width` **(required)**           | CSS length           | n/a     | Sets element width (e.g. `320px`, `100%`).                                                                                    |
+| `height`                         | CSS length           | n/a     | Sets host element height.                                                                                                     |
+| `fullscreen`                     | boolean              | off     | When present, the viewer takes over the viewport (`position: fixed; top/left: 0; width/height: 100vw/100vh; z-index: 9999`). |
+| `bgColor`                        | CSS color            | `#f2f2f2` | Background color. Hex and rgb(a) supported.                                                                                   |
+| `fov`                            | number (deg)         | `55`    | Camera field-of-view.                                                                                                         |
+| `minZoom`, `maxZoom`             | number               | auto    | Minimum and maximum zoom allowed.                                                                                             |
+| `minCameraTilt`, `maxCameraTilt` | number (deg)         | `10` / `85` | Pitch angle clamps.                                                                                                           |
+| `initialCameraAngle`             | string `"yaw pitch"` | `"0 0"` | Starting camera position horizontal and vertical (e.g. `-45 90`).                                                             |
 
 **Behavioral notes**
 
-* If neither `width`/`height` nor `fullscreen` is set, size the host via CSS. The component enforces a minimum height fallback when collapsed.
+* If neither `width` or `height` nor `fullscreen` is set, size the host via CSS. The component enforces a minimum height fallback when collapsed.
 
 ---
 
-
-> Only one viewer is active at a time by design. Activating another instance resets the previously active one, to ensure performance.
+> Only one viewer is active at a time by design. Activating another instance resets the previously active one to ensure performance.
 
 ---
 
 ## Troubleshooting
 
-* **Nothing renders:** Verify `model-id` is correct and provisioned. Check that your page height/width is non‑zero.
-* **Zoom feels too strong/weak:** Tune `minZoom`/`maxZoom`; values are relative to model size.
-* **Camera starts at odd angle:** Use `initialCameraAngle="yaw pitch"` to override the default.
-* **Layout clipped on small tiles:** Provide explicit `height` on the host container (e.g., cards in a grid).
+* **Nothing renders:** Verify `model-id` is correct and provisioned. Check that your page height or width is non-zero.
+* **Zoom feels too strong or too weak:** Tune `minZoom` and `maxZoom`. Values are relative to model size.
+* **Camera starts at an odd angle:** Use `initialCameraAngle="yaw pitch"` to override the default.
+* **Layout clipped on small tiles:** Provide an explicit `height` on the host container (for example, cards in a grid).
 
+---
+
+## Google Analytics
+
+You can connect the Marvify Model Viewer to your own Google Analytics 4 (GA4) setup. This lets you track how visitors interact with your 3D models directly in GA reports.
+
+### Quick setup
+
+1. Ensure GA4 is installed on your site, or use Google Tag Manager with a GA4 tag.
+2. Add your GA measurement ID to the Marvify script tag.
+
+```html
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<!-- Your GA4 setup -->
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+<!-- add your measurement-id to the script import -->
+<script src="https://js.marvify.io/marvify.js" type="module"
+        data-ga4-id="G-XXXXXXXXXX"></script>
+
+<marvify-model-viewer model-id="demo" style="width:300px; height:300px"></marvify-model-viewer>
+```
+
+Replace `G-XXXXXXXXXX` with your own GA4 measurement ID.
+
+---
+
+### Events tracked
+
+The viewer automatically sends three standard events to GA, once per viewer activation.
+
+* `marvify_viewer_session_requested`: 
+  * fired when a visitor/auto-play activates the viewer, for example a click to start.
+* `marvify_viewer_session_displayed`: 
+  * fired when the model successfully loads.
+* `marvify_viewer_session_interacted`: 
+  * fired on the first interaction post-load, for example click, orbit, zoom, or gesture.
+
+---
+
+### Customizing event names
+
+If you prefer different event names, remap them using a script attribute.
+
+```html
+<script src="https://js.marvify.io/marvify.js" type="module"
+        data-ga4-id="G-XXXXXXXXXX"
+        data-insights-rename='{
+          "marvify_viewer_session_requested":"viewer_use",
+          "marvify_viewer_session_displayed":"viewer_display",
+          "marvify_viewer_session_interacted":"viewer_interact"
+        }'></script>
+```
+
+---
+
+### Sending events to GTM
+
+If you already use **Google Tag Manager (GTM)** as your analytics hub, you can forward Marvify events into `dataLayer`. From there, you decide how to route them inside GTM (for example, into GA4, or any other tool).
+
+**Step 1 – Add a global handler**
+
+```html
+<script>
+  window.dataLayer = window.dataLayer || [];
+  window.MarvifyEventHandler = function(eventName, payload) {
+    window.dataLayer.push({
+      event: eventName,
+      ...payload
+    });
+  };
+</script>
+```
+
+**Step 2 - Tell the viewer to use that handler**
+
+```html
+<script src="https://js.marvify.io/marvify.js" type="module"
+        data-insights-handler="MarvifyEventHandler"></script>
+```
+
+Once configured, Marvify events will appear in your dataLayer. Inside GTM, you can create Custom Event triggers for these events and attach GA4 or other tags as needed.
+
+---
+
+With this setup, your 3D viewer interactions appear in Google Analytics just like any other events. You can keep the defaults, rename them, or fully customize routing through GTM.


### PR DESCRIPTION
Adds a concise Google Analytics 4 integration guide to the Marvify Model Viewer docs. The guide shows quick setup with GA4, the three emitted events, optional event renaming, and a GTM-first handler pattern for routing via dataLayer. A Swedish version of the same section is included.